### PR TITLE
Adding code to space-pad the version string query for Fortran.

### DIFF
--- a/src/fortran/fortran.c
+++ b/src/fortran/fortran.c
@@ -51,6 +51,7 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 
 #include "fortran-common.h"
 
@@ -1274,7 +1275,18 @@ void FORTRANIFY (shmem_info_get_version) (int *major, int *minor)
 
 void FORTRANIFY (shmem_info_get_name) (char *name)
 {
+    int len;
+    const int max_f_len = _SHMEM_MAX_NAME_LEN - 1;
+
+    /* get the C string */
     shmem_info_get_name (name);
+
+    /* pad with spaces for Fortran (TODO: memset better?) */
+    len = strlen (name);
+    while (len < max_f_len) {
+        name[len] = ' ';
+        len += 1;
+    }
 }
 
 #if defined(HAVE_FEATURE_EXPERIMENTAL)

--- a/src/querying/info.c
+++ b/src/querying/info.c
@@ -55,5 +55,10 @@ shmem_info_get_version (int * major, int * minor)
 void
 shmem_info_get_name (char *name)
 {
-    strncpy (name, _SHMEM_VENDOR_STRING, _SHMEM_MAX_NAME_LEN);
+    snprintf (name,
+              _SHMEM_MAX_NAME_LEN,
+              "OpenSHMEM: %s, version %d.%d",
+              _SHMEM_VENDOR_STRING,
+              _SHMEM_MAJOR_VERSION, _SHMEM_MINOR_VERSION
+              );
 }

--- a/src/shmem.fh
+++ b/src/shmem.fh
@@ -47,8 +47,9 @@
       integer SHMEM_MINOR_VERSION
       parameter ( SHMEM_MINOR_VERSION = 2 )
 
+! one less than C's length
       integer SHMEM_MAX_NAME_LEN
-      parameter ( SHMEM_MAX_NAME_LEN = 64 )
+      parameter ( SHMEM_MAX_NAME_LEN = 64 - 1 )
 
       character ( len = SHMEM_MAX_NAME_LEN ) SHMEM_VENDOR_STRING
       parameter ( SHMEM_VENDOR_STRING = "UH Reference Implementation" )


### PR DESCRIPTION
Adjust Fortran string length to be C's - 1 (see redmine #200)