### PR TITLE
Update debugging to pass name of calling routine where error happened

### DIFF
--- a/src/alltoall/alltoall.c
+++ b/src/alltoall/alltoall.c
@@ -116,12 +116,13 @@ shmem_alltoall32 (void *target, const void* source, size_t nelems,
                   int PE_start, int logPE_stride, int PE_size,
                   long *pSync)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_alltoall32");
+    INIT_CHECK (debug_name);
     shmem_quiet ();
 
-    SYMMETRY_CHECK (target, 1, "shmem_alltoall32");
-    SYMMETRY_CHECK (source, 2, "shmem_alltoall32");
-    SYMMETRY_CHECK (pSync,  7, "shmem_alltoall32");
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync,  7, debug_name);
 
     func32 (target, source, 1, 1, nelems,
             PE_start, logPE_stride, PE_size, pSync);
@@ -137,12 +138,13 @@ shmem_alltoall64 (void *target, const void* source, size_t nelems,
                   int PE_start, int logPE_stride, int PE_size,
                   long *pSync)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_alltoall64");
+    INIT_CHECK (debug_name);
     shmem_quiet ();
 
-    SYMMETRY_CHECK (target, 1, "shmem_alltoall64");
-    SYMMETRY_CHECK (source, 2, "shmem_alltoall64");
-    SYMMETRY_CHECK (pSync,  7, "shmem_alltoall64");
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync,  7, debug_name);
 
     func64 (target, source, 1, 1, nelems,
             PE_start, logPE_stride, PE_size, pSync);
@@ -159,12 +161,13 @@ shmem_alltoalls32 (void *target, const void* source,
                    int PE_start, int logPE_stride, int PE_size,
                    long *pSync)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_alltoalls32");
+    INIT_CHECK (debug_name);
     shmem_quiet ();
 
-    SYMMETRY_CHECK (target, 1, "shmem_alltoalls32");
-    SYMMETRY_CHECK (source, 2, "shmem_alltoalls32");
-    SYMMETRY_CHECK (pSync,  9, "shmem_alltoalls32");
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync,  9, debug_name);
 
     func32 (target, source, dst, sst, nelems,
             PE_start, logPE_stride, PE_size, pSync);
@@ -181,12 +184,13 @@ shmem_alltoalls64 (void *target, const void* source,
                    int PE_start, int logPE_stride, int PE_size,
                    long *pSync)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_alltoalls64");
+    INIT_CHECK (debug_name);
     shmem_quiet ();
 
-    SYMMETRY_CHECK (target, 1, "shmem_alltoalls64");
-    SYMMETRY_CHECK (source, 2, "shmem_alltoalls64");
-    SYMMETRY_CHECK (pSync,  9, "shmem_alltoalls64");
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync,  9, debug_name);
 
     func64 (target, source, dst, sst, nelems,
             PE_start, logPE_stride, PE_size, pSync);

--- a/src/atomic/atomic.c
+++ b/src/atomic/atomic.c
@@ -95,8 +95,9 @@ shmemi_atomic_finalize (void)
     Type                                                                \
     shmem_##Name##_swap (Type *target, Type value, int pe)              \
     {                                                                   \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 3);                                         \
+        DEBUG_NAME ("shmem_" #Name "_swap");                            \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 3, debug_name);                             \
         return shmemi_comms_swap_request_##Name (target, value,         \
                                                  pe);                   \
     }
@@ -126,8 +127,9 @@ SHMEM_TYPE_SWAP (float, float);
     Type                                                                \
     shmem_##Name##_cswap (Type *target, Type cond, Type value, int pe)  \
     {                                                                   \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        DEBUG_NAME ("shmem_" #Name "_swap");                            \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         return shmemi_comms_cswap_request_##Name (target, cond, value,  \
                                                   pe);                  \
     }
@@ -149,8 +151,9 @@ SHMEM_TYPE_CSWAP (longlong, long long);
     Type                                                                \
     shmem_##Name##_fadd (Type *target, Type value, int pe)              \
     {                                                                   \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 3);                                         \
+        DEBUG_NAME ("shmem_" #Name "_fadd");                            \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 3, debug_name);                             \
         return shmemi_comms_fadd_request_##Name (target, value,         \
                                                  pe);                   \
     }
@@ -178,8 +181,9 @@ SHMEM_TYPE_FADD (longlong, long long);
     Type                                                        \
     shmem_##Name##_finc (Type *target, int pe)                  \
     {                                                           \
-        INIT_CHECK ();                                          \
-        PE_RANGE_CHECK (pe, 2);                                 \
+        DEBUG_NAME ("shmem_" #Name "_finc");                    \
+        INIT_CHECK (debug_name);                                \
+        PE_RANGE_CHECK (pe, 2, debug_name);                     \
         return shmemi_comms_finc_request_##Name (target,        \
                                                  pe);           \
     }
@@ -205,8 +209,9 @@ SHMEM_TYPE_FINC (longlong, long long);
     void                                                                \
     shmem_##Name##_add (Type *target, Type value, int pe)               \
     {                                                                   \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 3);                                         \
+        DEBUG_NAME ("shmem_" #Name "_add");                             \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 3, debug_name);                             \
         shmemi_comms_add_request_##Name (target,                        \
                                          value,                         \
                                          pe);                           \
@@ -230,8 +235,9 @@ SHMEM_TYPE_ADD (longlong, long long);
     void                                                        \
     shmem_##Name##_inc (Type *target, int pe)                   \
     {                                                           \
-        INIT_CHECK ();                                          \
-        PE_RANGE_CHECK (pe, 2);                                 \
+        DEBUG_NAME ("shmem_" #Name "_inc");                     \
+        INIT_CHECK (debug_name);                                \
+        PE_RANGE_CHECK (pe, 2, debug_name);                     \
         shmemi_comms_inc_request_##Name (target,                \
                                          pe);                   \
     }
@@ -259,14 +265,15 @@ SHMEM_TYPE_INC (longlong, long long);
 #define shmem_double_fetch pshmem_double_fetch
 #endif /* HAVE_FEATURE_PSHMEM */
 
-#define SHMEM_TYPE_FETCH(Name, Type)                              \
-    Type                                                          \
-    shmem_##Name##_fetch (const Type *target, int pe)             \
-    {                                                             \
-        INIT_CHECK ();                                            \
-        PE_RANGE_CHECK (pe, 2);                                   \
+#define SHMEM_TYPE_FETCH(Name, Type)                                \
+    Type                                                            \
+    shmem_##Name##_fetch (const Type *target, int pe)               \
+    {                                                               \
+        DEBUG_NAME ("shmem_" #Name "_fetch");                       \
+        INIT_CHECK (debug_name);                                    \
+        PE_RANGE_CHECK (pe, 2, debug_name);                         \
         return shmemi_comms_fetch_request_##Name ((Type *) target,  \
-                                                  pe);            \
+                                                  pe);              \
     }
 
 SHMEM_TYPE_FETCH (int, int);
@@ -293,8 +300,9 @@ SHMEM_TYPE_FETCH (double, double);
     void                                                          \
     shmem_##Name##_set (Type *target, Type value, int pe)         \
     {                                                             \
-        INIT_CHECK ();                                            \
-        PE_RANGE_CHECK (pe, 2);                                   \
+        DEBUG_NAME ("shmem_" #Name "_set");                       \
+        INIT_CHECK (debug_name);                                  \
+        PE_RANGE_CHECK (pe, 2, debug_name);                       \
         shmemi_comms_set_request_##Name (target, value,           \
                                          pe);                     \
     }
@@ -322,8 +330,9 @@ SHMEM_TYPE_SET (double, double);
     void                                                                \
     shmemx_##Name##_xor (Type *target, Type value, int pe)              \
     {                                                                   \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 3);                                         \
+        DEBUG_NAME ("shmem_" #Name "_xor");                             \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 3, debug_name);                             \
         shmemi_comms_xor_request_##Name (target, value,                 \
                                          pe);                           \
     }

--- a/src/barrier-all/barrier-all.c
+++ b/src/barrier-all/barrier-all.c
@@ -100,7 +100,8 @@ shmemi_barrier_all_dispatch_init (void)
 void
 shmem_barrier_all (void)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_barrier_all");
+    INIT_CHECK (debug_name);
 
     shmem_quiet ();
 

--- a/src/barrier/barrier.c
+++ b/src/barrier/barrier.c
@@ -117,7 +117,8 @@ shmemi_barrier_dispatch_init (void)
 void
 shmem_barrier (int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_barrier");
+    INIT_CHECK (debug_name);
 
     shmem_quiet ();
 

--- a/src/broadcast/broadcast.c
+++ b/src/broadcast/broadcast.c
@@ -108,11 +108,12 @@ shmem_broadcast32 (void *target, const void *source, size_t nelems,
                    int PE_root, int PE_start, int logPE_stride, int PE_size,
                    long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_broadcast32");
-    SYMMETRY_CHECK (source, 2, "shmem_broadcast32");
-    SYMMETRY_CHECK (pSync, 8, "shmem_broadcast32");
-    PE_RANGE_CHECK (PE_start, 5);
+    DEBUG_NAME ("shmem_broadcast32");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 8, debug_name);
+    PE_RANGE_CHECK (PE_start, 5, debug_name);
 
     func32 (target, source, nelems,
             PE_root, PE_start, logPE_stride, PE_size, pSync);
@@ -128,11 +129,12 @@ shmem_broadcast64 (void *target, const void *source, size_t nelems,
                    int PE_root, int PE_start, int logPE_stride, int PE_size,
                    long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_broadcast64");
-    SYMMETRY_CHECK (source, 2, "shmem_broadcast64");
-    SYMMETRY_CHECK (pSync, 8, "shmem_broadcast64");
-    PE_RANGE_CHECK (PE_start, 5);
+    DEBUG_NAME ("shmem_broadcast64");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 8, debug_name);
+    PE_RANGE_CHECK (PE_start, 5, debug_name);
 
     func64 (target, source, nelems,
             PE_root, PE_start, logPE_stride, PE_size, pSync);

--- a/src/collect/collect-linear.c
+++ b/src/collect/collect-linear.c
@@ -78,10 +78,6 @@
         /* TODO: temp fix: I know barrier doesn't use this many indices */ \
         long *acc_off = & (pSync[SHMEM_COLLECT_SYNC_SIZE - 1]);         \
                                                                         \
-        INIT_CHECK();                                                   \
-        SYMMETRY_CHECK(target, 1, "shmem_collect");                     \
-        SYMMETRY_CHECK(source, 2, "shmem_collect");                     \
-                                                                        \
         shmemi_trace(SHMEM_LOG_COLLECT,                                 \
                      "nelems = %ld, PE_start = %d, PE_stride = %d,"     \
                      " PE_size = %d, last_pe = %d",                     \

--- a/src/collect/collect.c
+++ b/src/collect/collect.c
@@ -104,12 +104,13 @@ void
 shmem_collect32 (void *target, const void *source, size_t nelems,
                  int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_collect32");
-    SYMMETRY_CHECK (source, 2, "shmem_collect32");
-    SYMMETRY_CHECK (pSync, 7, "shmem_collect32");
-    PE_RANGE_CHECK (PE_start, 4);
-    /* PE_RANGE_CHECK (PE_size, 6); */
+    DEBUG_NAME ("shmem_collect32");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 7, debug_name);
+    PE_RANGE_CHECK (PE_start, 4, debug_name);
+    /* PE_RANGE_CHECK (PE_size, 6, debug_name); */
 
     func32 (target, source, nelems, PE_start, logPE_stride, PE_size, pSync);
 }
@@ -129,12 +130,13 @@ void
 shmem_collect64 (void *target, const void *source, size_t nelems,
                  int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_collect64");
-    SYMMETRY_CHECK (source, 2, "shmem_collect64");
-    SYMMETRY_CHECK (pSync, 7, "shmem_collect64");
-    PE_RANGE_CHECK (PE_start, 4);
-    /* PE_RANGE_CHECK (PE_size, 6); */
+    DEBUG_NAME ("shmem_collect64");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 7, debug_name);
+    PE_RANGE_CHECK (PE_start, 4, debug_name);
+    /* PE_RANGE_CHECK (PE_size, 6, debug_name); */
 
     func64 (target, source, nelems, PE_start, logPE_stride, PE_size, pSync);
 }

--- a/src/fcollect/fcollect-linear.c
+++ b/src/fcollect/fcollect-linear.c
@@ -79,9 +79,6 @@
         const size_t tidx = nelems * Bytes * vpe;                       \
         int i;                                                          \
         int pe = PE_start;                                              \
-        INIT_CHECK();                                                   \
-        SYMMETRY_CHECK(target, 1, "shmem_fcollect");                    \
-        SYMMETRY_CHECK(source, 2, "shmem_fcollect");                    \
         for (i = 0; i < PE_size; i += 1) {                              \
             shmem_put##Bits(target + tidx, source, nelems, pe);         \
             pe += step;                                                 \

--- a/src/fcollect/fcollect.c
+++ b/src/fcollect/fcollect.c
@@ -109,12 +109,13 @@ void
 shmem_fcollect32 (void *target, const void *source, size_t nelems,
                   int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_fcollect32");
-    SYMMETRY_CHECK (source, 2, "shmem_fcollect32");
-    SYMMETRY_CHECK (pSync, 7, "shmem_fcollect32");
-    PE_RANGE_CHECK (PE_start, 4);
-    /* PE_RANGE_CHECK (PE_size, 6); */
+    DEBUG_NAME ("shmem_fcollect32");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 7, debug_name);
+    PE_RANGE_CHECK (PE_start, 4, debug_name);
+    /* PE_RANGE_CHECK (PE_size, 6, debug_name); */
 
     func32 (target, source, nelems, PE_start, logPE_stride, PE_size, pSync);
 }
@@ -134,12 +135,13 @@ void
 shmem_fcollect64 (void *target, const void *source, size_t nelems,
                   int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmem_fcollect64");
-    SYMMETRY_CHECK (source, 2, "shmem_fcollect64");
-    SYMMETRY_CHECK (pSync, 7, "shmem_fcollect64");
-    PE_RANGE_CHECK (PE_start, 4);
-    /* PE_RANGE_CHECK (PE_size, 6); */
+    DEBUG_NAME ("shmem_fcollect64");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    SYMMETRY_CHECK (pSync, 7, debug_name);
+    PE_RANGE_CHECK (PE_start, 4, debug_name);
+    /* PE_RANGE_CHECK (PE_size, 6, debug_name); */
 
     func64 (target, source, nelems, PE_start, logPE_stride, PE_size, pSync);
 }

--- a/src/fence/fence.c
+++ b/src/fence/fence.c
@@ -63,7 +63,8 @@
 void
 shmem_fence (void)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_fence");
+    INIT_CHECK (debug_name);
     shmemi_comms_fence_request ();
 }
 

--- a/src/fence/quiet.c
+++ b/src/fence/quiet.c
@@ -63,7 +63,8 @@
 void
 shmem_quiet (void)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_quiet");
+    INIT_CHECK (debug_name);
     shmemi_comms_quiet_request ();
 }
 

--- a/src/fortran/fortran-mem.c
+++ b/src/fortran/fortran-mem.c
@@ -100,11 +100,12 @@ extern long malloc_error;
 void FORTRANIFY (shpalloc) (uintptr_t **addr, int *length,
                             int *errcode, int *abort)
 {
+    DEBUG_NAME ("shpalloc");
     /* convert 32-bit words to bytes */
     const int scale = sizeof (int32_t);
     void *symm_addr;
 
-    INIT_CHECK ();
+    INIT_CHECK (debug_name);
 
     if (*length <= 0) {
         *errcode = SHMEM_MALLOC_BAD_SIZE;
@@ -158,7 +159,8 @@ void FORTRANIFY (shpalloc) (uintptr_t **addr, int *length,
 
 void FORTRANIFY (shpdeallc) (uintptr_t **addr, int *errcode, int *abort)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shpdeallc");
+    INIT_CHECK (debug_name);
 
     shmemi_trace (SHMEM_LOG_MEMORY,
                   "shpdeallc(addr = %p, errcode = %d, abort = %d)",
@@ -203,7 +205,8 @@ void FORTRANIFY (shpdeallc) (uintptr_t **addr, int *errcode, int *abort)
 void FORTRANIFY (shpclmove) (uintptr_t **addr, int *length,
                              int *errcode, int *abort)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shpclmove");
+    INIT_CHECK (debug_name);
 
     *addr = shmem_realloc (*addr, *length);
 

--- a/src/memory/symmem.c
+++ b/src/memory/symmem.c
@@ -171,8 +171,6 @@ shmalloc_nb (size_t size)
 {
     void *addr;
 
-    INIT_CHECK ();
-
 #ifdef HAVE_FEATURE_DEBUG
     if (__shmalloc_symmetry_check (size) != -1) {
         malloc_error = SHMEM_MALLOC_SYMMSIZE_FAILED;
@@ -218,12 +216,16 @@ shmalloc_private (size_t size)
 void *
 shmalloc (size_t size)
 {
+    DEBUG_NAME ("shmalloc");
+    INIT_CHECK (debug_name);
     return shmalloc_private (size);
 }
 
 void *
 shmem_malloc (size_t size)
 {
+    DEBUG_NAME ("shmem_malloc");
+    INIT_CHECK (debug_name);
     return shmalloc_private (size);
 }
 
@@ -243,8 +245,6 @@ shmem_malloc (size_t size)
 void
 shfree_nb (void *addr)
 {
-    INIT_CHECK ();
-
     if (addr == (void *) NULL) {
         shmemi_trace (SHMEM_LOG_MEMORY,
                       "address passed to shfree() already null");
@@ -285,12 +285,16 @@ shfree_private (void *addr)
 void
 shfree (void *addr)
 {
+    DEBUG_NAME ("shfree");
+    INIT_CHECK (debug_name);
     shfree_private (addr);
 }
 
 void
 shmem_free (void *addr)
 {
+    DEBUG_NAME ("shmem_free");
+    INIT_CHECK (debug_name);
     shfree_private (addr);
 }
 
@@ -307,8 +311,6 @@ static inline void *
 shrealloc_private (void *addr, size_t size)
 {
     void *newaddr;
-
-    INIT_CHECK ();
 
     if (addr == (void *) NULL) {
         shmemi_trace (SHMEM_LOG_MEMORY,
@@ -357,12 +359,16 @@ shrealloc_private (void *addr, size_t size)
 void *
 shrealloc (void *addr, size_t size)
 {
+    DEBUG_NAME ("shrealloc");
+    INIT_CHECK (debug_name);
     return shrealloc_private (addr, size);
 }
 
 void *
 shmem_realloc (void *addr, size_t size)
 {
+    DEBUG_NAME ("shmem_realloc");
+    INIT_CHECK (debug_name);
     return shrealloc_private (addr, size);
 }
 
@@ -380,8 +386,6 @@ static inline void *
 shmemalign_private (size_t alignment, size_t size)
 {
     void *addr;
-
-    INIT_CHECK ();
 
 #ifdef HAVE_FEATURE_DEBUG
     if (__shmalloc_symmetry_check (size) != -1) {
@@ -415,12 +419,16 @@ shmemalign_private (size_t alignment, size_t size)
 void *
 shmemalign (size_t alignment, size_t size)
 {
+    DEBUG_NAME ("shmemalign");
+    INIT_CHECK (debug_name);
     return shmemalign_private (alignment, size);
 }
 
 void *
 shmem_align (size_t alignment, size_t size)
 {
+    DEBUG_NAME ("shmem_align");
+    INIT_CHECK (debug_name);
     return shmemalign_private (alignment, size);
 }
 
@@ -470,10 +478,11 @@ extern char *sherror (void);    /* ! API */
 char *
 sherror (void)
 {
+    DEBUG_NAME ("sherror");
     malloc_error_code_t *etp = error_table;
     int i;
 
-    INIT_CHECK ();
+    INIT_CHECK (debug_name);
 
     for (i = 0; i < nerrors; i += 1) {
         if (malloc_error == etp->code) {

--- a/src/ptp/putget.c
+++ b/src/ptp/putget.c
@@ -109,10 +109,11 @@ extern void shmem_complexd_put (COMPLEXIFY (double) * dest,
     void                                                                \
     shmem_##Name##_put (Type *dest, const Type *src, size_t nelems, int pe) \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_put");                             \
         const size_t typed_nelems = nelems * sizeof (Type);             \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (dest, 1, "shmem_" #Name "_put");                \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (dest, 1, debug_name);                           \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_put (dest, (void *) src, typed_nelems, pe);        \
     }
 
@@ -148,9 +149,10 @@ shmem_put128 (void *dest, const void *src, size_t nelems, int pe)
 void
 shmem_putmem (void *dest, const void *src, size_t nelems, int pe)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (dest, 1, "shmem_putmem");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmem_putmem");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (dest, 1, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_put_bulk (dest, (void *) src, nelems, pe);
 }
 
@@ -198,10 +200,11 @@ extern void shmem_complexd_get (COMPLEXIFY (double) * dest,
     void                                                                \
     shmem_##Name##_get (Type *dest, const Type *src, size_t nelems, int pe) \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_get");                             \
         const size_t typed_nelems = nelems * sizeof (Type);             \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (src, 2, "shmem_" #Name "_get");                 \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (src, 2, debug_name);                            \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_get (dest, (void *) src, typed_nelems, pe);        \
     }
 
@@ -237,9 +240,10 @@ shmem_get128 (void *dest, const void *src, size_t nelems, int pe)
 void
 shmem_getmem (void *dest, const void *src, size_t nelems, int pe)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (src, 2, "shmem_getmem");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmem_getmem");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (src, 2, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_get_bulk (dest, (void *) src, nelems, pe);
 }
 

--- a/src/ptp/putget_nb.c
+++ b/src/ptp/putget_nb.c
@@ -97,10 +97,11 @@ extern void shmemx_put_nb (long *dest, const long *src,
     shmemx_##Name##_put_nb (Type *target, const Type *source, size_t nelems, \
                             int pe, shmemx_request_handle_t *desc)      \
     {                                                                   \
-        int typed_nelems = sizeof(Type) * nelems;                       \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (target, 1, "shmemx_" #Name "_put_nb");          \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        DEBUG_NAME ("shmemx_" #Name "_put_nb");                         \
+        const int typed_nelems = sizeof(Type) * nelems;                 \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (target, 1, debug_name);                         \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_put_nb ((Type *) target, (Type *) source,          \
                              typed_nelems, pe, desc);                   \
     }
@@ -152,9 +153,10 @@ void
 shmemx_putmem_nb (void *target, const void *source, size_t nelems,
                   int pe, shmemx_request_handle_t * desc)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (target, 1, "shmemx_putmem_nb");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmemx_putmem_nb");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (target, 1, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_put_nb (target, (void *) source, nelems, pe, desc);
 }
 
@@ -201,10 +203,11 @@ extern void shmemx_get_nb (long *dest, const long *src,
     shmemx_##Name##_get_nb (Type *target, const Type *source, size_t nelems, \
                             int pe, shmemx_request_handle_t *desc)      \
     {                                                                   \
-        int typed_nelems = sizeof(Type) * nelems;                       \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (source, 2, "shmemx_" #Name "_get_nb");          \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        DEBUG_NAME ("shmemx_" #Name "_get_nb");                         \
+        const int typed_nelems = sizeof(Type) * nelems;                 \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (source, 2, debug_name);                         \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_get_nb ((Type *) target, (Type *) source,          \
                              typed_nelems, pe, desc);                   \
     }
@@ -257,9 +260,10 @@ void
 shmemx_getmem_nb (void *target, const void *source, size_t nelems,
                   int pe, shmemx_request_handle_t * desc)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (source, 2, "shmemx_getmem_nb");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmemx_getmem_nb");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (source, 2, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_get_nb (target, (void *) source, nelems, pe, desc);
 }
 

--- a/src/ptp/putget_nbi.c
+++ b/src/ptp/putget_nbi.c
@@ -110,10 +110,11 @@ extern void shmem_complexd_put_nbi (COMPLEXIFY (double) * dest,
     shmem_##Name##_put_nbi (Type *dest, const Type *src,                \
                             size_t nelems, int pe)                      \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_put_nbi");                         \
         const size_t typed_nelems = nelems * sizeof (Type);             \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (dest, 1, "shmem_" #Name "_put_nbi");            \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (dest, 1, debug_name);                           \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_put_nbi (dest, (void *) src, typed_nelems, pe);    \
     }
 
@@ -149,9 +150,10 @@ shmem_put128_nbi (void *dest, const void *src, size_t nelems, int pe)
 void
 shmem_putmem_nbi (void *dest, const void *src, size_t nelems, int pe)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (dest, 1, "shmem_putmem_nbi");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmem_putmem_nbi");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (dest, 1, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_put_nbi_bulk (dest, (void *) src, nelems, pe);
 }
 
@@ -200,10 +202,11 @@ extern void shmem_complexd_get_nbi (COMPLEXIFY (double) * dest,
     shmem_##Name##_get_nbi (Type *dest, const Type *src,                \
                             size_t nelems, int pe)                      \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_get_nbi");                         \
         const size_t typed_nelems = nelems * sizeof (Type);             \
-        INIT_CHECK ();                                                  \
-        SYMMETRY_CHECK (src, 2, "shmem_" #Name "_get_nbi");             \
-        PE_RANGE_CHECK (pe, 4);                                         \
+        INIT_CHECK (debug_name);                                        \
+        SYMMETRY_CHECK (src, 2, debug_name);                            \
+        PE_RANGE_CHECK (pe, 4, debug_name);                             \
         shmemi_comms_get_nbi (dest, (void *) src, typed_nelems, pe);    \
     }
 
@@ -239,8 +242,9 @@ shmem_get128_nbi (void *dest, const void *src, size_t nelems, int pe)
 void
 shmem_getmem_nbi (void *dest, const void *src, size_t nelems, int pe)
 {
-    INIT_CHECK ();
-    SYMMETRY_CHECK (src, 2, "shmem_getmem_nbi");
-    PE_RANGE_CHECK (pe, 4);
+    DEBUG_NAME ("shmem_getmem_nbi");
+    INIT_CHECK (debug_name);
+    SYMMETRY_CHECK (src, 2, debug_name);
+    PE_RANGE_CHECK (pe, 4, debug_name);
     shmemi_comms_get_nbi_bulk (dest, (void *) src, nelems, pe);
 }

--- a/src/ptp/strided.c
+++ b/src/ptp/strided.c
@@ -104,14 +104,15 @@ extern void shmem_char_iget (char *target, const char *source, ptrdiff_t tst,
     shmem_##Name##_iput (Type *target, const Type *source,              \
                          ptrdiff_t tst, ptrdiff_t sst, size_t nelems, int pe) \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_iput");                            \
         size_t ti = 0, si = 0;                                          \
         size_t i;                                                       \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 6);                                         \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 6, debug_name);                             \
         for (i = 0; i < nelems; i += 1) {                               \
             shmem_##Name##_p (& (target[ti]), source[si], pe);          \
-                ti += tst;                                              \
-                si += sst;                                              \
+            ti += tst;                                                  \
+            si += sst;                                                  \
         }                                                               \
     }
 
@@ -185,14 +186,15 @@ shmem_iput128 (void *target, const void *source,
     shmem_##Name##_iget (Type *target, const Type *source,              \
                          ptrdiff_t tst, ptrdiff_t sst, size_t nelems, int pe) \
     {                                                                   \
+        DEBUG_NAME ("shmem_" #Name "_iget");                            \
         size_t ti = 0, si = 0;                                          \
         size_t i;                                                       \
-        INIT_CHECK ();                                                  \
-        PE_RANGE_CHECK (pe, 6);                                         \
+        INIT_CHECK (debug_name);                                        \
+        PE_RANGE_CHECK (pe, 6, debug_name);                             \
         for (i = 0; i < nelems; i += 1) {                               \
             target[ti] = shmem_##Name##_g ((Type *) & (source[si]), pe); \
-                ti += tst;                                              \
-                si += sst;                                              \
+            ti += tst;                                                  \
+            si += sst;                                                  \
         }                                                               \
     }
 

--- a/src/querying/accessible.c
+++ b/src/querying/accessible.c
@@ -66,7 +66,8 @@
 int
 shmem_pe_accessible (int pe)
 {
-    INIT_CHECK ();
+    DEBUG_NAME ("shmem_pe_accessible");
+    INIT_CHECK (debug_name);
     /*
      * don't trap this here, need to just test in program flow
      * PE_RANGE_CHECK (pe, 1);
@@ -81,7 +82,8 @@ shmem_pe_accessible (int pe)
 int
 shmem_addr_accessible (const void *addr, int pe)
 {
-    INIT_CHECK ();
-    PE_RANGE_CHECK (pe, 2);
+    DEBUG_NAME ("shmem_addr_accessible");
+    INIT_CHECK (debug_name);
+    PE_RANGE_CHECK (pe, 2, debug_name);
     return shmemi_symmetric_addr_accessible ((void *) addr, pe);
 }

--- a/src/querying/ptr.c
+++ b/src/querying/ptr.c
@@ -70,12 +70,14 @@
 void *
 shmem_ptr (const void *target, int pe)
 {
-    INIT_CHECK ();
-    PE_RANGE_CHECK (pe, 2);
+    DEBUG_NAME ("shmem_ptr");
+    INIT_CHECK (debug_name);
+    PE_RANGE_CHECK (pe, 2, debug_name);
 
 #ifdef SHMEM_PUTGET_SHARED_MEMORY
 
-    shmemi_trace (SHMEM_LOG_NOTICE, "shmem_ptr() not implemented yet");
+    shmemi_trace (SHMEM_LOG_NOTICE,
+                  "shmem_ptr() not implemented yet");
     return (void *) NULL;
 
 #else /* ! SHMEM_PUTGET_SHARED_MEMORY */

--- a/src/querying/query.c
+++ b/src/querying/query.c
@@ -52,13 +52,6 @@
 #include "pshmem.h"
 #endif /* HAVE_FEATURE_PSHMEM */
 
-static inline int
-mype_helper (void)
-{
-    INIT_CHECK ();
-    return GET_STATE (mype);
-}
-
 #ifdef HAVE_FEATURE_PSHMEM
 #pragma weak _my_pe = p_my_pe
 #define _my_pe p_my_pe
@@ -69,20 +62,17 @@ mype_helper (void)
 int
 _my_pe (void)
 {
-    return mype_helper ();
+    DEBUG_NAME ("_my_pe");
+    INIT_CHECK (debug_name);
+    return GET_STATE (mype);
 }
 
 int
 shmem_my_pe (void)
 {
-    return mype_helper ();
-}
-
-static inline int
-numpes_helper (void)
-{
-    INIT_CHECK ();
-    return GET_STATE (numpes);
+    DEBUG_NAME ("shmem_my_pe");
+    INIT_CHECK (debug_name);
+    return GET_STATE (mype);
 }
 
 #ifdef HAVE_FEATURE_PSHMEM
@@ -95,11 +85,15 @@ numpes_helper (void)
 int
 _num_pes (void)
 {
-    return numpes_helper ();
+    DEBUG_NAME ("_num_pes");
+    INIT_CHECK (debug_name);
+    return GET_STATE (numpes);
 }
 
 int
 shmem_n_pes (void)
 {
-    return numpes_helper ();
+    DEBUG_NAME ("shmem_n_pes");
+    INIT_CHECK (debug_name);
+    return GET_STATE (numpes);
 }

--- a/src/reduce/reduce-op.c
+++ b/src/reduce/reduce-op.c
@@ -384,9 +384,10 @@ SHMEM_UDR_TYPE_OP (complexf, float complex);
                                      int PE_size,                       \
                                      Type *pWrk, long *pSync)           \
     {                                                                   \
-        INIT_CHECK();                                                   \
-        SYMMETRY_CHECK(target, 1, "shmem_" #Name "_" #OpCall "_to_all"); \
-        SYMMETRY_CHECK(source, 2, "shmem_" #Name "_" #OpCall "_to_all"); \
+        DEBUG_NAME ("shmem_" #Name "_" #OpCall "_to_all");              \
+        INIT_CHECK(debug_name);                                         \
+        SYMMETRY_CHECK(target, 1, debug_name);                          \
+        SYMMETRY_CHECK(source, 2, debug_name);                          \
         shmemi_udr_##Name##_to_all(OpCall##_##Name##_func,              \
                                    target, source, nreduce,             \
                                    PE_start, logPE_stride, PE_size,     \

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -61,17 +61,20 @@
  *
  */
 
-#define INIT_CHECK()                                                    \
+#define DEBUG_NAME(Name) const char *debug_name = Name
+
+#define INIT_CHECK(subrname)                                            \
     IF_DEBUGGING(                                                       \
                  const int s = GET_STATE (pe_status);                   \
-                 if (s != PE_RUNNING)                                   \
-                     {                                                  \
-                         shmemi_trace (SHMEM_LOG_FATAL,                 \
-                                       "Library is not running, reason: %s", \
-                                       shmemi_state_as_string (s)       \
-                                       );                               \
-                         /* NOT REACHED */                              \
-                     }                                                  \
+                 if (s != PE_RUNNING) {                                 \
+                     fprintf (stderr,                                   \
+                              "OpenSHMEM: Called %s() but %s\n",        \
+                              subrname,                                 \
+                              shmemi_state_as_string (s)                \
+                              );                                        \
+                     exit (EXIT_FAILURE);                               \
+                     /* NOT REACHED */                                  \
+                 }                                                      \
                                                                         )
 
 /*
@@ -81,15 +84,15 @@
 
 #include "trace.h"
 
-#define PE_RANGE_CHECK(pe, argpos)                                      \
+#define PE_RANGE_CHECK(pe, argpos, subrname)                            \
     IF_DEBUGGING(                                                       \
                  const int bot_pe = 0;                                  \
                  const int top_pe = GET_STATE (numpes) - 1;             \
                  if (pe < bot_pe || pe > top_pe) {                      \
                      shmemi_trace (SHMEM_LOG_FATAL,                     \
-                                   "PE %d in argument #%d not"          \
+                                   "PE %d in argument #%d of %s() not"  \
                                    " within allocated range %d .. %d",  \
-                                   pe, argpos,                          \
+                                   pe, argpos, subrname,                \
                                    bot_pe, top_pe                       \
                                    );                                   \
                      /* NOT REACHED */                                  \
@@ -110,7 +113,7 @@
                      {                                                  \
                          shmemi_trace (SHMEM_LOG_FATAL,                 \
                                        "%s(), argument #%d @ %p"        \
-                                       "is not symmetric",              \
+                                       " is not symmetric",             \
                                        subrname, argpos, addr           \
                                        );                               \
                          /* NOT REACHED */                              \
@@ -123,29 +126,28 @@
 
 #define TXRX_LENGTH_CHECK(len, argpos, subrname)                        \
     IF_DEBUGGING(                                                       \
-                 if ((len) == 0)                                        \
-                     {                                                  \
-                         shmemi_trace (SHMEM_LOG_INFO,                  \
-                                       "%s(), length in argument #%d"   \
-                                       "is zero, call has no effect",   \
-                                       subrname, argpos                 \
-                                       );                               \
-                     }                                                  \
-                 if ((len) < 0)                                         \
-                     {                                                  \
-                         shmemi_trace (SHMEM_LOG_INFO,                  \
-                                       "%s(), length in argument #%d"   \
-                                       "is negative, call has no effect", \
-                                       subrname, argpos                 \
-                                       );                               \
-                     }                                                  \
+                 if ((len) == 0) {                                      \
+                     shmemi_trace (SHMEM_LOG_INFO,                      \
+                                   "%s(), length in argument #%d"       \
+                                   " is zero, call has no effect",      \
+                                   subrname, argpos                     \
+                                   );                                   \
+                 }                                                      \
+                 if ((len) < 0) {                                       \
+                     shmemi_trace (SHMEM_LOG_INFO,                      \
+                                   "%s(), length in argument #%d"       \
+                                   " is negative, call has no effect",  \
+                                   subrname, argpos                     \
+                                   );                                   \
+                 }                                                      \
                                                                         \
-                                                    )
+                                                                        )
 
 #else /* ! HAVE_FEATURE_DEBUG */
 
-#define INIT_CHECK()
-#define PE_RANGE_CHECK(pe, argpos)
+#define DEBUG_NAME(name)
+#define INIT_CHECK(subrname)
+#define PE_RANGE_CHECK(pe, argpos, subrname)
 #define SYMMETRY_CHECK(addr, argpos, subrname)
 #define TXRX_LENGTH_CHECK(len, argpos, subrname)
 


### PR DESCRIPTION
move debug checks out of internal routines.