### PR TITLE
Put brackets around the elapsed time in trace messages

### DIFF
--- a/src/utils/trace.c
+++ b/src/utils/trace.c
@@ -443,7 +443,7 @@ shmemi_trace (shmem_trace_t msg_type, char *fmt, ...)
         va_list ap;
 
         snprintf (tmp1, TRACE_MSG_BUF_SIZE,
-                  "%-8.8f PE %d: %s: ",
+                  "[%-8.8f] PE %d: %s: ",
                   shmemi_elapsed_clock_get (),
                   GET_STATE (mype), level_to_string (msg_type));
 


### PR DESCRIPTION
Simple formatting tweak to make the time more visible