### PR TITLE
Remove gasnet ldflags. 

### DIFF
--- a/src/comms/gasnet/oshcc.in
+++ b/src/comms/gasnet/oshcc.in
@@ -67,4 +67,4 @@ case "$progname" in
         ;;
 esac
 
-$driver -I$SHMEM_INC_DIR $SHMEM_LDFLAGS $GASNET_LDFLAGS "$@" $SHMEM_LIBS $GASNET_LIBS
+$driver -I$SHMEM_INC_DIR $SHMEM_LDFLAGS "$@" $SHMEM_LIBS $GASNET_LIBS


### PR DESCRIPTION
 This hopefully will stop the wrappers from complaining about unknown flags to end-user compilers.