### PR TITLE
Allow make to continue if LaTeX packages missing

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -82,8 +82,8 @@ REMOVE   = rm -f
 #
 
 %.pdf:	%.tex
-	-pdflatex $<
-	-pdflatex $<
+	-pdflatex $< </dev/null
+	-pdflatex $< </dev/null
 
 all default:	$(IMPL_PDF)	$(MAN_PAGES)
 


### PR DESCRIPTION
Redirect from dev-null, stop LaTeX prompting.